### PR TITLE
add check for existing pinned tabs, before opening a new set

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,6 +3,13 @@ import { openPinnedTabs } from './utils.js';
 // event listener for when a new window is created
 chrome.windows.onCreated.addListener((window) => {
 	const newWindowId = window.id;
-	// open pinned tabs
-	openPinnedTabs(newWindowId);
+	// check existing pinned tabs
+	chrome.tabs.query({ pinned: true }).then((openedPinnedTabs) => {
+		// close existing pinned tabs, if any
+		const openedPinnedTabIds = openedPinnedTabs.map((tab) => tab.id);
+		chrome.tabs.remove(openedPinnedTabIds).then(() => {
+			// open fresh pinned tabs
+			openPinnedTabs(newWindowId);
+		});
+	});
 });


### PR DESCRIPTION
On new window create, add query for pinned tabs, and close any if they exist. Then open saved tabs.

Closes #4 